### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,9 +141,9 @@ The class name will be different from the model, avoiding the IDE duplicate anno
 
 > Please make sure to back up your models, before writing the info.
 
-Writing to the models should keep the existing comments and only append new properties/methods.
+Writing to the models should keep the existing comments and only append new properties/methods. It will not update changed properties/methods.
 
-With the `--reset (-R)` option, the existing PHPDoc is replaced, or added if not found.
+With the `--reset (-R)` option, the whole existing PHPDoc is replaced, including any comments that have been made. The `--smart-reset` option will instead keep the 'text' part of the phpdoc comment, and just replace all the property/method defininitions.
 
 ```bash
 php artisan ide-helper:models "App\Models\Post"

--- a/README.md
+++ b/README.md
@@ -142,8 +142,8 @@ The class name will be different from the model, avoiding the IDE duplicate anno
 > Please make sure to back up your models, before writing the info.
 
 Writing to the models should keep the existing comments and only append new properties/methods.
-The existing PHPDoc is replaced, or added if not found.
-With the `--reset (-R)` option, the existing PHPDocs are ignored, and only the newly found columns/relations are saved as PHPDocs.
+
+With the `--reset (-R)` option, the existing PHPDoc is replaced, or added if not found.
 
 ```bash
 php artisan ide-helper:models "App\Models\Post"


### PR DESCRIPTION
Clarified model behaviour when using the --reset option

## Summary
The documentation currently reads as though the `--reset` option in the `ide-helper:models` command will only add new columns and ignore the current phpdocs. I believe this is misleading, since the `--reset` behaviour appears to overwrite the docs in full whereas not using it just appends newly added columns. This PR clarifies the behaviour.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Misc. change (internal, infrastructure, maintenance, etc.)

### Checklist
- [x] Existing tests have been adapted and/or new tests have been added
- [ ] Add a CHANGELOG.md entry
- [x] Update the README.md
- [x] Code style has been fixed via `composer fix-style`
